### PR TITLE
Update TodoReview.py

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -200,7 +200,10 @@ class WorkerThread(threading.Thread):
 						filepath = filepath[len(filepath) - 1]  + '/' + path.basename(m['filepath'])
 					else:
 						filepath = path.basename(m['filepath'])
-					spaces = ' '*(settings.get('render_spaces', 1) - len(filepath + ':' + str(m['linenum'])))
+
+					extraSpaces = 3 - len(str(idx));
+					
+					spaces = ' '*((settings.get('render_spaces', 1) + extraSpaces) - len(filepath + ':' + str(m['linenum'])))
 					line = u"{idx}. {filepath}:{linenum}{spaces}{msg}".format(idx=idx, filepath=filepath, linenum=m['linenum'], spaces=spaces, msg=msg)
 					yield ('result', line, m)
 


### PR DESCRIPTION
Taking into account the length of the index number to align the notes accordingly. Notes 1-9 were off by one space when using the render_spaces option. This should keep all aligned up to 999. Hopefully no one has that many TODOs!
