### PR TITLE
Add "Open Files"-only to command palette.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,6 +4,11 @@
 		"command": "todo_review"
 	},
 	{
+		"caption": "TodoReview: Open Files",
+		"command": "todo_review",
+		"args": { "open_files": true, "open_files_only": true }
+	},
+	{
 		"caption": "TodoReview: Project and Open Files",
 		"command": "todo_review",
 		"args": { "open_files": true }


### PR DESCRIPTION
I saw this feature was available, and I wanted easy access to open-files-only, so I added the default command to do it.
Thanks for the useful plugin!

![todo](https://cloud.githubusercontent.com/assets/423610/6063634/c609a36e-ad26-11e4-946d-f8ae7534f751.png)
