### PR TITLE
prevent plugin crash if `forms` is NoneType

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -282,7 +282,7 @@ class TodoReviewRender(sublime_plugin.TextCommand):
 		forms = settings.get('render_header_format', '%d - %c files in %t secs')
 		datestr = settings.get('render_header_date', '%A %m/%d/%y at %I:%M%p')
 
-		if len(forms) == 0:
+		if not forms:
 			return
 
 		date = datetime.datetime.now().strftime(datestr)


### PR DESCRIPTION
i'm not totally clear on *why*, but it's possible that `forms` may be NoneType and todoreview will error out while indexing files. this allows drawheader to bail correctly.

feel free to disregard if you have some other fix for this or if it's part of some other issue