### PR TITLE
Fix #144: follow symlinks when looking for project directories

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -65,7 +65,8 @@ class Engine():
 		seen_paths = []
 
 		for dirpath in self.dirpaths:
-			for dirp, dirnames, filepaths in os.walk(self.resolve(dirpath)):
+			dirpath = self.resolve(dirpath)
+			for dirp, dirnames, filepaths in os.walk(dirpath, followlinks=True):
 
 				if any(p.search(dirp) for p in self.exclude_folders):
 					continue


### PR DESCRIPTION
If any directory in a project is a symlink then this directory will not be analyzed.

Steps to reproduce:
1. Create symlink to a directory inside any project's dir.
2. Create a file with TODO comment there.
3. Close that file.
4. Run command "TodoReview: Project Files"