### PR TITLE
Fix symlinked path problem (see issue #107)

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -113,7 +113,7 @@ class Engine():
 		return self.extract(self.files())
 
 	def resolve(self, directory):
-		return os.path.realpath(os.path.expanduser(os.path.abspath(directory)))
+		return os.path.expanduser(os.path.abspath(directory))
 
 class Thread(threading.Thread):
 	def __init__(self, engine, callback):


### PR DESCRIPTION
Removed use of `os.path.realpath()`. See [this discussion](https://github.com/jonathandelgado/SublimeTodoReview/issues/107#issuecomment-369203975)