### PR TITLE
test if files exist before adding to list of files

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -167,7 +167,7 @@ class TodoReviewCommand(sublime_plugin.TextCommand):
 					paths = window.folders()
 				else:
 					for p in paths:
-						if os.path.isfile(p):
+						if os.path.isfile(p) and os.path.exists(filepath):
 							filepaths.append(p)
 			else:
 				paths = []


### PR DESCRIPTION
This is a resolution to problems discussed in #155 and #107.

As far as I can tell, the only way a broken symlink can get into the list of files is [here](https://github.com/jonathandelgado/SublimeTodoReview/blob/master/TodoReview.py#L173), where files in the command argument `paths` or in the view setting `include_paths` are added to the list.

The current test only checks `os.path.isfile()`, which [returns `True` for broken symlinks](https://docs.python.org/3.5/library/os.path.html#os.path.isfile). I've added a test for `os.path.exists()`, which will return [`False` for broken symlinks](https://docs.python.org/3.5/library/os.path.html#os.path.exists) in python 3 and [python 2](https://docs.python.org/2.7/library/os.path.html#os.path.exists).