### PR TITLE
Add auto folder render depth option

### DIFF
--- a/TodoReview.py
+++ b/TodoReview.py
@@ -277,8 +277,16 @@ class TodoReviewRender(sublime_plugin.TextCommand):
 	def draw_file(self, item):
 		if settings.get('render_include_folder', False):
 			depth = settings.get('render_folder_depth', 1)
-			f = os.path.dirname(item['file']).replace('\\', '/').split('/')
-			f = '/'.join(f[-depth:] + [os.path.basename(item['file'])])
+			if depth == 'auto':
+				f = item['file']
+				for folder in sublime.active_window().folders():
+					if f.startswith(folder):
+						f = os.path.relpath(f, folder)
+						break
+				f = f.replace('\\', '/')
+			else:
+				f = os.path.dirname(item['file']).replace('\\', '/').split('/')
+				f = '/'.join(f[-depth:] + [os.path.basename(item['file'])])
 		else:
 			f = os.path.basename(item['file'])
 		return '%f:%l' \

--- a/TodoReview.py
+++ b/TodoReview.py
@@ -276,7 +276,7 @@ class TodoReviewRender(sublime_plugin.TextCommand):
 
 	def draw_file(self, item):
 		if settings.get('render_include_folder', False):
-			depth = settings.get('render_folder_depth', 1)
+			depth = settings.get('render_folder_depth', 'auto')
 			if depth == 'auto':
 				f = item['file']
 				for folder in sublime.active_window().folders():

--- a/TodoReview.py
+++ b/TodoReview.py
@@ -276,7 +276,7 @@ class TodoReviewRender(sublime_plugin.TextCommand):
 
 	def draw_file(self, item):
 		if settings.get('render_include_folder', False):
-			depth = settings.get('render_folder_depth', 'auto')
+			depth = settings.get('render_folder_depth', 1)
 			if depth == 'auto':
 				f = item['file']
 				for folder in sublime.active_window().folders():

--- a/TodoReview.sublime-settings
+++ b/TodoReview.sublime-settings
@@ -14,7 +14,7 @@
 	"resolve_symlinks": true,
 	"case_sensitive": false,
 	"render_include_folder": true,
-	"render_folder_depth": 1,
+	"render_folder_depth": "auto",
 	"render_maxspaces": 50,
 	"render_header_format": "%d - %c files in %t secs",
 	"render_header_date": "%A %m/%d/%y at %I:%M%p",

--- a/TodoReview.sublime-settings
+++ b/TodoReview.sublime-settings
@@ -14,7 +14,7 @@
 	"resolve_symlinks": true,
 	"case_sensitive": false,
 	"render_include_folder": true,
-	"render_folder_depth": "auto",
+	"render_folder_depth": 1,
 	"render_maxspaces": 50,
 	"render_header_format": "%d - %c files in %t secs",
 	"render_header_date": "%A %m/%d/%y at %I:%M%p",

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,8 @@ Additionally, if you choose to include folders in your report, you may also spec
 "render_folder_depth": 5
 ```
 
+If you are using Sublime in a project or have folders open, you may find it helpful to set `"render_folder_depth"` to `"auto"`, which will render folders in the report up to any folders you have open. For example, if you're working on a project rooted at `/home/user/code/project`, and you have a TODO in `/home/user/code/project/src/file.cpp`, the report would render the file as `src/file.cpp`.
+
 ## Align results
 TodoReview now automatically aligns the comments for you, calculating the largest result and aligning the rest accordingly. The system default for maximum spaces is `50`, which prevents a single file with an abnormally long length completely ruining your results. You can change this setting by editing `render_maxspaces`
 

--- a/readme.md
+++ b/readme.md
@@ -162,12 +162,14 @@ If you are planning on using any non UTF-8 characters in your comments, you may 
 ## Include folders in results
 If you have a large project with repeating file names, it is sometimes useful to also have the file's folder displayed in the results. This would turn the result `index.js:1` to `lib/index.js:1`. Results are sorted alphabetically to group folders and files together. Please note that results are sorted by priority first. This defaults to `false`.
 
-Additionally, if you choose to include folders in your report, you may also specify the folder depth for your report paths. The default folder depth is `"auto"`, which if you are using Sublime in a project or have folders open, will render folders in the report up to any folders you have open. For example, if you're working on a project rooted at `/home/user/code/project`, and you have a TODO in `/home/user/code/project/src/file.cpp`, the report would render the file as `src/file.cpp`. Setting the folder depth to a number will always render that many folders.
+Additionally, if you choose to include folders in your report, you may also specify the folder depth for your report paths.
 
 ```javascript
 "render_include_folder": true,
-"render_folder_depth": "auto"
+"render_folder_depth": 5
 ```
+
+If you are using Sublime in a project or have folders open, you may find it helpful to set `"render_folder_depth"` to `"auto"`, which will render folders in the report up to any folders you have open. For example, if you're working on a project rooted at `/home/user/code/project`, and you have a TODO in `/home/user/code/project/src/file.cpp`, the report would render the file as `src/file.cpp`.
 
 ## Align results
 TodoReview now automatically aligns the comments for you, calculating the largest result and aligning the rest accordingly. The system default for maximum spaces is `50`, which prevents a single file with an abnormally long length completely ruining your results. You can change this setting by editing `render_maxspaces`

--- a/readme.md
+++ b/readme.md
@@ -162,14 +162,12 @@ If you are planning on using any non UTF-8 characters in your comments, you may 
 ## Include folders in results
 If you have a large project with repeating file names, it is sometimes useful to also have the file's folder displayed in the results. This would turn the result `index.js:1` to `lib/index.js:1`. Results are sorted alphabetically to group folders and files together. Please note that results are sorted by priority first. This defaults to `false`.
 
-Additionally, if you choose to include folders in your report, you may also specify the folder depth for your report paths.
+Additionally, if you choose to include folders in your report, you may also specify the folder depth for your report paths. The default folder depth is `"auto"`, which if you are using Sublime in a project or have folders open, will render folders in the report up to any folders you have open. For example, if you're working on a project rooted at `/home/user/code/project`, and you have a TODO in `/home/user/code/project/src/file.cpp`, the report would render the file as `src/file.cpp`. Setting the folder depth to a number will always render that many folders.
 
 ```javascript
 "render_include_folder": true,
-"render_folder_depth": 5
+"render_folder_depth": "auto"
 ```
-
-If you are using Sublime in a project or have folders open, you may find it helpful to set `"render_folder_depth"` to `"auto"`, which will render folders in the report up to any folders you have open. For example, if you're working on a project rooted at `/home/user/code/project`, and you have a TODO in `/home/user/code/project/src/file.cpp`, the report would render the file as `src/file.cpp`.
 
 ## Align results
 TodoReview now automatically aligns the comments for you, calculating the largest result and aligning the rest accordingly. The system default for maximum spaces is `50`, which prevents a single file with an abnormally long length completely ruining your results. You can change this setting by editing `render_maxspaces`


### PR DESCRIPTION
Fixes #165

Makes the default `render_folder_depth` setting to be `auto`, which will render folders up to any open folders in the window.